### PR TITLE
Update manifest to Binary 0.3 and GNOME Platform 46

### DIFF
--- a/io.github.fizzyizzy05.binary.json
+++ b/io.github.fizzyizzy05.binary.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.fizzyizzy05.binary",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "45",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "binary",
     "finish-args" : [
@@ -30,7 +30,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/fizzyizzy05/binary",
-                    "tag" : "0.2.1"
+                    "tag" : "0.3"
                 }
             ]
         }


### PR DESCRIPTION
Update Binary itself to 0.3, which includes and update to the GNOME 46 platform.